### PR TITLE
Fixed doubles from parameters rounding to int incorrectly causing missed pitches and sequencer dimensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ smtg_enable_vst3_sdk()
 smtg_add_vst3plugin(BigSequencer
     source/version.h
     source/plugids.h
+    source/util.h
     source/scales.h
     source/scales.cpp
     source/sequencer.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ project(BigSequencer
     # This is your plug-in version number. Change it here only.
     # Version number symbols usable in C++ can be found in
     # source/version.h and ${PROJECT_BINARY_DIR}/projectversion.h.
-    VERSION 1.0.0.0 
+    VERSION 0.1.2.0
     DESCRIPTION "BigSequencer VST 3 Plug-in"
 )
 

--- a/source/bigsequencercontroller.cpp
+++ b/source/bigsequencercontroller.cpp
@@ -6,6 +6,7 @@
 #include "bigsequencercids.h"
 #include "base/source/fstreamer.h"
 #include "vstgui/plugin-bindings/vst3editor.h"
+#include "util.h"
 #include "plugids.h"
 #include "scales.h"
 #include "notedatagenerator.h"
@@ -184,42 +185,42 @@ tresult PLUGIN_API BigSequencerController::setComponentState (IBStream* state)
 	}
 	sequencer.setNotes(width, height, noteDatas);
 
-	setParamNormalized(kParamSequencerWidthId, (float)(width - Sequencer::minWidth) / (Sequencer::maxWidth - Sequencer::minWidth));
-	setParamNormalized(kParamSequencerHeightId, (float)(height - Sequencer::minHeight) / (Sequencer::maxHeight - Sequencer::minHeight));
+	setParamNormalized(kParamSequencerWidthId, ilerp<uint8_t>(Sequencer::minWidth, Sequencer::maxWidth, width));
+	setParamNormalized(kParamSequencerHeightId, ilerp<uint8_t>(Sequencer::minHeight, Sequencer::maxHeight, height));
 
 	setParamNormalized(kParamCursor1ActiveId, cursors[0].active);
-	setParamNormalized(kParamCursor1NoteIntervalId, (float)cursors[0].interval / (totalIntervals - 1));
-	setParamNormalized(kParamCursor1PitchOffsetId, (float)(cursors[0].pitchOffset - Cursor::pitchMin) / (Cursor::pitchMax - Cursor::pitchMin));
+	setParamNormalized(kParamCursor1NoteIntervalId, ilerp<uint8_t>(0, totalIntervals - 1, cursors[0].interval));
+	setParamNormalized(kParamCursor1PitchOffsetId, ilerp(Cursor::pitchMin, Cursor::pitchMax, cursors[0].pitchOffset));
 	setParamNormalized(kParamCursor1NoteLengthId, cursors[0].getNoteLength());
 	setParamNormalized(kParamCursor1VelocityId, cursors[0].velocity);
 	setParamNormalized(kParamCursor1ProbabilityId, cursors[0].probability);
 
 	setParamNormalized(kParamCursor2ActiveId, cursors[1].active);
-	setParamNormalized(kParamCursor2NoteIntervalId, (float)cursors[1].interval / (totalIntervals - 1));
-	setParamNormalized(kParamCursor2PitchOffsetId, (float)(cursors[1].pitchOffset - Cursor::pitchMin) / (Cursor::pitchMax - Cursor::pitchMin));
+	setParamNormalized(kParamCursor2NoteIntervalId, ilerp<uint8_t>(0, totalIntervals - 1, cursors[1].interval));
+	setParamNormalized(kParamCursor2PitchOffsetId, ilerp(Cursor::pitchMin, Cursor::pitchMax, cursors[1].pitchOffset));
 	setParamNormalized(kParamCursor2NoteLengthId, cursors[1].getNoteLength());
 	setParamNormalized(kParamCursor2VelocityId, cursors[1].velocity);
 	setParamNormalized(kParamCursor2ProbabilityId, cursors[1].probability);
 
 	setParamNormalized(kParamCursor3ActiveId, cursors[2].active);
-	setParamNormalized(kParamCursor3NoteIntervalId, (float)cursors[2].interval / (totalIntervals - 1));
-	setParamNormalized(kParamCursor3PitchOffsetId, (float)(cursors[2].pitchOffset - Cursor::pitchMin) / (Cursor::pitchMax - Cursor::pitchMin));
+	setParamNormalized(kParamCursor3NoteIntervalId, ilerp<uint8_t>(0, totalIntervals - 1, cursors[2].interval));
+	setParamNormalized(kParamCursor3PitchOffsetId, ilerp(Cursor::pitchMin, Cursor::pitchMax, cursors[2].pitchOffset));
 	setParamNormalized(kParamCursor3NoteLengthId, cursors[2].getNoteLength());
 	setParamNormalized(kParamCursor3VelocityId, cursors[2].velocity);
 	setParamNormalized(kParamCursor3ProbabilityId, cursors[2].probability);
 
 	setParamNormalized(kParamCursor4ActiveId, cursors[3].active);
-	setParamNormalized(kParamCursor4NoteIntervalId, (float)cursors[3].interval / (totalIntervals - 1));
-	setParamNormalized(kParamCursor4PitchOffsetId, (float)(cursors[3].pitchOffset - Cursor::pitchMin) / (Cursor::pitchMax - Cursor::pitchMin));
+	setParamNormalized(kParamCursor4NoteIntervalId, ilerp<uint8_t>(0, totalIntervals - 1, cursors[3].interval));
+	setParamNormalized(kParamCursor4PitchOffsetId, ilerp(Cursor::pitchMin, Cursor::pitchMax, cursors[3].pitchOffset));
 	setParamNormalized(kParamCursor4NoteLengthId, cursors[3].getNoteLength());
 	setParamNormalized(kParamCursor4VelocityId, cursors[3].velocity);
 	setParamNormalized(kParamCursor4ProbabilityId, cursors[3].probability);
 
-	setParamNormalized(kParamSeedId, (float)seed / INT32_MAX);
-	setParamNormalized(kParamScaleId, scale / (float)(totalScales - 1));
-	setParamNormalized(kParamRootNoteId, rootNote / (float)(totalPitches - 1));
-	setParamNormalized(kParamMinNoteId, (minNote - NoteDataGenerator::noteLowerBound) / (float)(NoteDataGenerator::noteUpperBound - NoteDataGenerator::noteLowerBound));
-	setParamNormalized(kParamMaxNoteId, (maxNote - NoteDataGenerator::noteLowerBound) / (float)(NoteDataGenerator::noteUpperBound - NoteDataGenerator::noteLowerBound));
+	setParamNormalized(kParamSeedId, (double)seed / INT32_MAX);
+	setParamNormalized(kParamScaleId, scale / (double)(totalScales - 1));
+	setParamNormalized(kParamRootNoteId, rootNote / (double)(totalPitches - 1));
+	setParamNormalized(kParamMinNoteId, ilerp<uint8_t>(NoteDataGenerator::noteLowerBound, NoteDataGenerator::noteUpperBound, minNote));
+	setParamNormalized(kParamMaxNoteId, ilerp<uint8_t>(NoteDataGenerator::noteLowerBound, NoteDataGenerator::noteUpperBound, maxNote));
 	setParamNormalized(kParamFillChanceId, fillChance);
 
 	if (viewAvailable) {

--- a/source/bigsequencerprocessor.cpp
+++ b/source/bigsequencerprocessor.cpp
@@ -6,6 +6,7 @@
 #include "bigsequencercids.h"
 #include "plugids.h"
 #include "scales.h"
+#include "util.h"
 
 #include "base/source/fstreamer.h"
 #include "pluginterfaces/vst/ivstparameterchanges.h"
@@ -145,7 +146,7 @@ namespace vargason::bigsequencer {
 					switch (paramQueue->getParameterId()) {
 					case SequencerParams::kParamSequencerWidthId:
 						if (paramQueue->getPoint(numPoints - 1, sampleOffset, value) == kResultTrue) {
-							int width = 1 + value * sequencer.maxWidth;
+							uint8_t width = lerp(sequencer.minWidth, sequencer.maxWidth, value);
 							sequencer.setSize(width, sequencer.getHeight());  // cursor could be out of bounds if we do this wrong
 							updateSeed(data);
 							regenerateGridNotes();
@@ -154,7 +155,7 @@ namespace vargason::bigsequencer {
 						break;
 					case SequencerParams::kParamSequencerHeightId:
 						if (paramQueue->getPoint(numPoints - 1, sampleOffset, value) == kResultTrue) {
-							int height = 1 + value * sequencer.maxHeight;
+							uint8_t height = lerp(sequencer.minHeight, sequencer.maxHeight, value);
 							sequencer.setSize(sequencer.getWidth(), height);
 							updateSeed(data);
 							regenerateGridNotes();
@@ -182,13 +183,13 @@ namespace vargason::bigsequencer {
 						break;
 					case SequencerParams::kParamCursor1NoteIntervalId:
 						if (paramQueue->getPoint(numPoints - 1, sampleOffset, value) == kResultTrue) {
-							sequencer.getCursor(0).interval = (Interval)(Interval::thirtySecondNote + (Interval::doubleWholeNote - Interval::thirtySecondNote) * value);
+							sequencer.getCursor(0).interval = (Interval)lerp(Interval::thirtySecondNote, Interval::doubleWholeNote, value);
 						}
 						break;
 					case SequencerParams::kParamCursor1PitchOffsetId:
 						if (paramQueue->getPoint(numPoints - 1, sampleOffset, value) == kResultTrue) {
 							Cursor& cursor = sequencer.getCursor(0);
-							cursor.pitchOffset = cursor.pitchMin + (cursor.pitchMax - cursor.pitchMin) * value;
+							cursor.pitchOffset = lerp(cursor.pitchMin, cursor.pitchMax, value);
 						}
 						break;
 					case SequencerParams::kParamCursor1VelocityId:
@@ -218,13 +219,13 @@ namespace vargason::bigsequencer {
 						break;
 					case SequencerParams::kParamCursor2NoteIntervalId:
 						if (paramQueue->getPoint(numPoints - 1, sampleOffset, value) == kResultTrue) {
-							sequencer.getCursor(1).interval = (Interval)(Interval::thirtySecondNote + (Interval::doubleWholeNote - Interval::thirtySecondNote) * value);
+							sequencer.getCursor(1).interval = (Interval)lerp(Interval::thirtySecondNote, Interval::doubleWholeNote, value);
 						}
 						break;
 					case SequencerParams::kParamCursor2PitchOffsetId:
 						if (paramQueue->getPoint(numPoints - 1, sampleOffset, value) == kResultTrue) {
 							Cursor& cursor = sequencer.getCursor(1);
-							cursor.pitchOffset = cursor.pitchMin + (cursor.pitchMax - cursor.pitchMin) * value;
+							cursor.pitchOffset = lerp(cursor.pitchMin, cursor.pitchMax, value);
 						}
 						break;
 					case SequencerParams::kParamCursor2VelocityId:
@@ -254,13 +255,13 @@ namespace vargason::bigsequencer {
 						break;
 					case SequencerParams::kParamCursor3NoteIntervalId:
 						if (paramQueue->getPoint(numPoints - 1, sampleOffset, value) == kResultTrue) {
-							sequencer.getCursor(2).interval = (Interval)(Interval::thirtySecondNote + (Interval::doubleWholeNote - Interval::thirtySecondNote) * value);
+							sequencer.getCursor(2).interval = (Interval)lerp(Interval::thirtySecondNote, Interval::doubleWholeNote, value);
 						}
 						break;
 					case SequencerParams::kParamCursor3PitchOffsetId:
 						if (paramQueue->getPoint(numPoints - 1, sampleOffset, value) == kResultTrue) {
 							Cursor& cursor = sequencer.getCursor(2);
-							cursor.pitchOffset = cursor.pitchMin + (cursor.pitchMax - cursor.pitchMin) * value;
+							cursor.pitchOffset = lerp(cursor.pitchMin, cursor.pitchMax, value);
 						}
 						break;
 					case SequencerParams::kParamCursor3VelocityId:
@@ -290,13 +291,13 @@ namespace vargason::bigsequencer {
 						break;
 					case SequencerParams::kParamCursor4NoteIntervalId:
 						if (paramQueue->getPoint(numPoints - 1, sampleOffset, value) == kResultTrue) {
-							sequencer.getCursor(3).interval = (Interval)(Interval::thirtySecondNote + (Interval::doubleWholeNote - Interval::thirtySecondNote) * value);
+							sequencer.getCursor(3).interval = (Interval)lerp(Interval::thirtySecondNote, Interval::doubleWholeNote, value);
 						}
 						break;
 					case SequencerParams::kParamCursor4PitchOffsetId:
 						if (paramQueue->getPoint(numPoints - 1, sampleOffset, value) == kResultTrue) {
 							Cursor& cursor = sequencer.getCursor(3);
-							cursor.pitchOffset = cursor.pitchMin + (cursor.pitchMax - cursor.pitchMin) * value;
+							cursor.pitchOffset = lerp(cursor.pitchMin, cursor.pitchMax, value);
 						}
 						break;
 					case SequencerParams::kParamCursor4VelocityId:
@@ -330,7 +331,7 @@ namespace vargason::bigsequencer {
 						break;
 					case SequencerParams::kParamMinNoteId:
 						if (paramQueue->getPoint(numPoints - 1, sampleOffset, value) == kResultTrue) {
-							minNote = NoteDataGenerator::noteLowerBound + (NoteDataGenerator::noteUpperBound - NoteDataGenerator::noteLowerBound) * value;
+							minNote = lerp(NoteDataGenerator::noteLowerBound, NoteDataGenerator::noteUpperBound, value);
 							updateSeed(data);
 							regenerateGridNotes();
 							sendSequencerUpdate();
@@ -338,7 +339,7 @@ namespace vargason::bigsequencer {
 						break;
 					case SequencerParams::kParamMaxNoteId:
 						if (paramQueue->getPoint(numPoints - 1, sampleOffset, value) == kResultTrue) {
-							maxNote = NoteDataGenerator::noteLowerBound + (NoteDataGenerator::noteUpperBound - NoteDataGenerator::noteLowerBound) * value;
+							maxNote = lerp(NoteDataGenerator::noteLowerBound, NoteDataGenerator::noteUpperBound, value);
 							updateSeed(data);
 							regenerateGridNotes();
 							sendSequencerUpdate();

--- a/source/sequencer.h
+++ b/source/sequencer.h
@@ -27,8 +27,8 @@ namespace vargason::bigsequencer {
 		uint8_t currentlyPlayingNote = 60;
 		double lastNoteTime = 0;
 
-		static const int pitchMin = -24;
-		static const int pitchMax = 24;
+		static const int8_t pitchMin = -24;
+		static const int8_t pitchMax = 24;
 
 		const double* numericIntervals = new double[7] {
 			0.125,

--- a/source/sequencerview.cpp
+++ b/source/sequencerview.cpp
@@ -30,8 +30,14 @@ namespace vargason::bigsequencer {
 
 		glMatrixMode(GL_MODELVIEW);
 		glLoadIdentity();
+		float sqrWidth;
+		if (sequencer->getWidth() > sequencer->getHeight()) {
+			sqrWidth = viewSize.getWidth() / sequencer->getWidth();
+		}
+		else {
+			sqrWidth = viewSize.getHeight() / sequencer->getHeight();
+		}
 
-		float sqrWidth = viewSize.getWidth() / sequencer->getWidth();
 		glBegin(GL_TRIANGLES);
 		for (int y = 0; y < sequencer->getHeight(); y++) {
 			for (int x = 0; x < sequencer->getWidth(); x++) {

--- a/source/util.h
+++ b/source/util.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <stdint.h>
+
+namespace vargason::bigsequencer {
+    template <typename T>
+    T lerp(T min, T max, double value) {
+        double temp = min + (max - min) * value;
+        if (temp > 0) {
+            temp += 0.5;
+        }
+        else {
+            temp -= 0.5;
+        }
+        return (T)temp;
+    }
+
+    template <typename V>
+    double ilerp(V min, V max, V value) {
+        return (double)(value - min) / (max - min);
+    }
+
+}

--- a/source/version.h
+++ b/source/version.h
@@ -16,5 +16,5 @@
 #define stringFileDescription	"BigSequencer VST3"
 #endif
 #define stringCompanyName		"Vargason\0"
-#define stringLegalCopyright	"Copyright(c) 2024 Vargason."
+#define stringLegalCopyright	"Copyright(c) 2024 Jared Vargason."
 #define stringLegalTrademarks	"VST is a trademark of Steinberg Media Technologies GmbH"


### PR DESCRIPTION
Also fixed sequencer view when height is greater than width cutting off some of the sequencer; now shows UI correctly